### PR TITLE
Change image caption name format (memberblock).

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.5.5 (unreleased)
 ------------------
 
+- Change image caption name format (memberblock).
+  [mathias.leimgruber]
+
 - Improve Widget for Selection when there are multiple persons with the same name.
   [tschanzt]
 

--- a/egov/contactdirectory/content/member.py
+++ b/egov/contactdirectory/content/member.py
@@ -164,7 +164,7 @@ class Member(base.ATCTContent):
         if not mtool.checkPermission('View', mitglied):
             return ''
         if mitglied:
-            return mitglied.Title()
+            return mitglied.Title(format='natural')
 
     getImageCaption = getImageAltText
 


### PR DESCRIPTION
Before it was different. 

Now:
![screen shot 2013-11-01 at 10 54 49 am](https://f.cloud.github.com/assets/437933/1452713/b8cac694-42db-11e3-9aa4-b823a46b0476.png)
