### PR TITLE
Remove ManagePortal-permission for language field for a contact-object.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.6.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Remove ManagePortal-permission for language field for a contact-object.
+  [elioschmutz]
 
 
 1.6 (2013-12-13)

--- a/egov/contactdirectory/content/contact.py
+++ b/egov/contactdirectory/content/contact.py
@@ -259,7 +259,6 @@ dates_fields = [contact_schema[key] for key in contact_schema.keys()
 for field in dates_fields:
     field.write_permission = permissions.ManagePortal
 
-contact_schema['language'].write_permission = permissions.ManagePortal
 contact_schema['location'].write_permission = permissions.ManagePortal
 
 


### PR DESCRIPTION
@maethu Remove ManagePortal-permission for language field for a contact-object to be able to edit the translated object without manager rights.
