### PR TITLE
Disable orphan feature.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.6.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Disable orphan feature.
+  [mbaechtold]
 
 
 1.6.2 (2014-07-11)

--- a/egov/contactdirectory/browser/folder_contacts_listing.pt
+++ b/egov/contactdirectory/browser/folder_contacts_listing.pt
@@ -37,7 +37,7 @@
                                         b_size python: type(b_size) == type([]) and b_size[-1] or b_size;
                                         b_start python:0;b_start request/b_start | b_start;
                                         b_range python: b_start==0 and 5 or 3;
-                                        folderContents python:Batch(view.list_contacts(), int(b_size), int(b_start), orphan=1,pagerange=int(b_range));
+                                        folderContents python:Batch(view.list_contacts(), int(b_size), int(b_start), pagerange=int(b_range));
                                         batch folderContents">
               <tal:listing condition="folderContents"
                            define="toLocalizedTime nocall:here/toLocalizedTime;">


### PR DESCRIPTION
Probably due to a bug in plone.batching, the orphan feature will cause an
orphan object to appear on the second last page as well as on the last page.
