### PR TITLE
Use block view from ftw.contentpage.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,9 @@ Changelog
 1.7.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- No longer use the deprecated "simplelayout.types.common". Use
+  "ftw.contentpage" instead.
+  [mbaechtold]
 
 
 1.7.2 (2015-09-23)

--- a/egov/contactdirectory/browser/views.py
+++ b/egov/contactdirectory/browser/views.py
@@ -8,7 +8,7 @@ from ftw.table.interfaces import ITableSourceConfig, ITableSource
 from plone.registry.interfaces import IRegistry
 from Products.CMFCore.utils import getToolByName
 from Products.Five.browser import BrowserView
-from simplelayout.types.common.browser.views import BlockView
+from ftw.contentpage.browser.textblock_view import TextBlockView
 from zope.component import adapts, getUtility
 from zope.interface import implements, Interface
 
@@ -69,7 +69,7 @@ class MemberView(BrowserView):
     """
 
 
-class MemberBlockView(BlockView):
+class MemberBlockView(TextBlockView):
     """
     """
 

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(name='egov.contactdirectory',
       install_requires=[
           'setuptools',
           'simplelayout.base',
-          'simplelayout.types.common',
+          'ftw.contentpage',
           'ftw.table',
           'ftw.tabbedview',
           'ftw.upgrade',


### PR DESCRIPTION
simplelayout.types.common is deprecated so we better make use of the block view from the more recent ftw.contentpage.

As discussed with @jone 
