### PR TITLE
Restrict versions of some dependencies so they don't pull in Plone 5.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.8.0 (unreleased)
 ------------------
 
+- Restrict versions of some dependencies so they don't pull in Plone 5.
+  [mbaechtold]
+
 - Add functionality to toggle showing memberships with the new
   show_memberships attribute.
   [elioschmutz]

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,8 @@ setup(name='egov.contactdirectory',
       include_package_data=True,
       zip_safe=False,
       install_requires=[
+          'collective.geo.openlayers >= 3.0',
+          'collective.geo.mapwidget >= 2.1, < 3.0',
           'setuptools',
           'simplelayout.base',
           'ftw.contentpage',

--- a/sources.cfg
+++ b/sources.cfg
@@ -3,10 +3,3 @@ extends = http://plonesource.org/sources.cfg
 extensions = mr.developer
 
 auto-checkout =
-
-# c.geo.mapwidget is incompatible with geopy >= 0.96
-# see https://github.com/collective/collective.geo.mapwidget/commit/81dfd91e666585c7a413f986ac9b5a8cee328cd4
-    collective.geo.mapwidget
-
-# c.geo.mapwidget master depends on c.geo.openlayers > 3.0, which hasn't been released yet
-    collective.geo.openlayers


### PR DESCRIPTION
This fixes the failing tests on our continuous integration server.
