### PR TITLE
Move sync command in it's own module.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 1.8.1 (unreleased)
 ------------------
 
+- Move sync command in it's own module.
+  This prevents an import error if the ldap extra is not installed.
+  [mathias.leimgruber]
+
 - Fix default_output_type of text-field in contact schema.
   Change it from html to x-html-save.
   [elioschmutz]

--- a/egov/contactdirectory/sync/command.py
+++ b/egov/contactdirectory/sync/command.py
@@ -1,0 +1,18 @@
+import sys
+import os
+
+
+def do_sync_profiles(self, args):
+    "{0}/sync.py".format(os.path.split(__file__)[0])
+    script = __file__
+    # execfile() needs the source file
+    if script.endswith('.pyc') or script.endswith('.pyo'):
+        script = script[:-1]
+    cmd = "import sys; sys.argv[:]=[];"
+    if len(self.options.args) > 1:
+        for arg in self.options.args[1:]:
+            cmd += 'sys.argv.append(r\'%s\');' % arg
+    cmd += 'execfile(r\'%s\')' % script
+    cmdline = self.get_startup_cmd(self.options.python, cmd)
+    exitstatus = os.system(cmdline)
+    sys.exit(exitstatus)

--- a/egov/contactdirectory/sync/sync.py
+++ b/egov/contactdirectory/sync/sync.py
@@ -299,20 +299,5 @@ def sync_contacts(context, ldap_records, delete=True, set_owner=False):
     )
 
 
-def do_sync_profiles(self, args):
-    script = __file__
-    # execfile() needs the source file
-    if script.endswith('.pyc') or script.endswith('.pyo'):
-        script = script[:-1]
-    cmd = "import sys; sys.argv[:]=[];"
-    if len(self.options.args) > 1:
-        for arg in self.options.args[1:]:
-            cmd += 'sys.argv.append(r\'%s\');' % arg
-    cmd += 'execfile(r\'%s\')' % script
-    cmdline = self.get_startup_cmd(self.options.python, cmd)
-    exitstatus = os.system(cmdline)
-    sys.exit(exitstatus)
-
-
 if __name__ == '__main__':
     main()

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,6 @@ setup(name='egov.contactdirectory',
       target = plone
 
       [plone.recipe.zope2instance.ctl]
-      sync_contacts = egov.contactdirectory.sync.sync:do_sync_profiles
+      sync_contacts = egov.contactdirectory.sync.command:do_sync_profiles
       """,
       )


### PR DESCRIPTION
This prevents an import error if the `ldap` extra is not installed.

Fixes #34 
