### PR TITLE
Add allowable_content_types for contacts text field.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,11 @@ Changelog
 1.8.1 (unreleased)
 ------------------
 
+- Add allowable_content_types for contacts text field.
+  This will remove the dropdown field to choose the contenttype on
+  the text-field widget.
+  [elioschmutz]
+
 - Move sync command in it's own module.
   This prevents an import error if the ldap extra is not installed.
   [mathias.leimgruber]

--- a/egov/contactdirectory/content/contact.py
+++ b/egov/contactdirectory/content/contact.py
@@ -187,6 +187,7 @@ schema = Schema((
             required=False,
             searchable=True,
             schemata="Erweitert",
+            allowable_content_types=('text/html', ),
             default_input_type='text/html',
             default_output_type='text/x-html-safe',
             widget=RichWidget(


### PR DESCRIPTION
This will remove the dropdown field to choose the contenttype on the text-field widget.
## Before:

![bildschirmfoto 2016-02-01 um 08 49 50](https://cloud.githubusercontent.com/assets/557005/12711553/2caab408-c8c1-11e5-8125-9a1abc7939cb.png)
## After:

![bildschirmfoto 2016-02-01 um 08 52 34](https://cloud.githubusercontent.com/assets/557005/12711560/37ecaa1a-c8c1-11e5-9a5d-36a3661adb24.png)
