### PR TITLE
Fix remove newline if no organization is given

### DIFF
--- a/egov/contactdirectory/browser/contact.pt
+++ b/egov/contactdirectory/browser/contact.pt
@@ -56,10 +56,12 @@
           <tr tal:condition="python: context.getZip() and context.getCity() and context.getAddress()">
             <th i18n:translate="label_address">Address</th>
             <td>
+              <tal:organization tal:condition="context/getOrganization">
                <span tal:content="context/getOrganization">XYZ GmbH</span><br />
-               <tal:block tal:condition="python: context.getFirstname() and context.getLastname()"><span tal:content="string:${context/getFirstname} ${context/getLastname}">
-                Hugo Boss
-              </span><br /></tal:block>
+              </tal:organization>
+              <tal:name tal:condition="python: context.getFirstname() and context.getLastname()">
+                <span tal:content="string:${context/getFirstname} ${context/getLastname}">Hugo Boss</span><br />
+              </tal:name>
               <span tal:replace="structure python: context.getAddress() and str(context.getAddress()).replace('\n', '<br />') or ''" /><br />
               <span tal:replace="context/getZip | nothing" />
               <span tal:replace="context/getCity | nothing" />


### PR DESCRIPTION
Das `<br>` der Organisation wurde in jedem Fall gerendert:

![bildschirmfoto 2016-03-11 um 09 48 59](https://cloud.githubusercontent.com/assets/557005/13697584/932df28c-e76e-11e5-9051-b2f70b293d13.png)

Neu wird die Organisation nur noch gerendert, wenn diese auch ausgefüllt wurde:

![bildschirmfoto 2016-03-11 um 09 49 07](https://cloud.githubusercontent.com/assets/557005/13697578/882958d6-e76e-11e5-96e7-ac3c7b5677fe.png)

Siehe auch https://github.com/4teamwork/egov.contactdirectory/pull/38

extranet: https://extranet.4teamwork.ch/support/zug/maintlog/10860
