### PR TITLE
Fix sync_contacts command execution.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.9.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix sync_contacts command execution.
+  [lknoepfel]
 
 
 1.9.0 (2016-03-30)

--- a/egov/contactdirectory/sync/command.py
+++ b/egov/contactdirectory/sync/command.py
@@ -3,8 +3,7 @@ import os
 
 
 def do_sync_profiles(self, args):
-    "{0}/sync.py".format(os.path.split(__file__)[0])
-    script = __file__
+    script = "{0}/sync.py".format(os.path.split(__file__)[0])
     # execfile() needs the source file
     if script.endswith('.pyc') or script.endswith('.pyo'):
         script = script[:-1]


### PR DESCRIPTION
Der `bin/instance sync_contacts` command hat seit dieser Änderung https://github.com/4teamwork/egov.contactdirectory/commit/cb894cbcfd6395f70600df443b151c8b3856d752 das `command.py` script ausgeführt nicht das `sync.py`. Damit funktioniert die LDAP->Contacts synchronisation nicht mehr.
