### PR TITLE
Use "python-ldap" < 3.0.0b1.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.9.4 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Use "python-ldap" < 3.0.0b1. [mbaechtold]
 
 
 1.9.3 (2017-01-05)

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ tests_require = ['plone.app.testing',
                  'ftw.testbrowser',
                  'ftw.zipexport',
                  'unittest2',
-                 'python-ldap',
+                 'python-ldap < 3.0.0b1',
                  'Products.PloneLDAP',
                  ]
 
@@ -54,7 +54,7 @@ setup(name='egov.contactdirectory',
       tests_require=tests_require,
       extras_require=dict(tests=tests_require,
                           zip_export=['ftw.zipexport'],
-                          ldap=['python-ldap', 'Products.PloneLDAP']),
+                          ldap=['python-ldap < 3.0.0b1', 'Products.PloneLDAP']),
 
       entry_points="""
       # -*- Entry points: -*-


### PR DESCRIPTION
"python-ldap" 3.0.0b1 released on 2017-12-04 changed the way it handles text and bytes (see https://python-ldap.readthedocs.io/en/latest/bytes_mode.html#what-s-text-and-what-s-bytes) which caused some tests to fail.

As a workaround, we need to use an older release of "python-ldap" until we can thoroughly investigate the implications of the changes in "python-ldap".