### PR TITLE
Fix tests

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ------------------
 
 - Use "python-ldap" < 3.0.0b1. [mbaechtold]
+- Use unittest instead of unittest2 for testing [jone]
 
 
 1.9.3 (2017-01-05)

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,7 @@ Changelog
 
 - Use "python-ldap" < 3.0.0b1. [mbaechtold]
 - Use unittest instead of unittest2 for testing [jone]
+- Drop support for Plone 4.2. [jone]
 
 
 1.9.3 (2017-01-05)

--- a/egov/contactdirectory/tests/__init__.py
+++ b/egov/contactdirectory/tests/__init__.py
@@ -1,7 +1,7 @@
 from egov.contactdirectory.testing import EGOV_CONTACTDIRECTORY_FUNCTIONAL_TESTING
 from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
-from unittest2 import TestCase
+from unittest import TestCase
 import transaction
 
 

--- a/egov/contactdirectory/tests/test_contact.py
+++ b/egov/contactdirectory/tests/test_contact.py
@@ -3,7 +3,7 @@ from egov.contactdirectory.tests import FunctionalTestCase
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
-from unittest2 import skipUnless
+from unittest import skipUnless
 
 
 class TestContact(FunctionalTestCase):

--- a/egov/contactdirectory/tests/test_export.py
+++ b/egov/contactdirectory/tests/test_export.py
@@ -6,7 +6,7 @@ from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
 from StringIO import StringIO
-from unittest2 import TestCase
+from unittest import TestCase
 from zipfile import ZipFile
 import os
 

--- a/egov/contactdirectory/tests/test_icon.py
+++ b/egov/contactdirectory/tests/test_icon.py
@@ -1,4 +1,4 @@
-from unittest2 import TestCase
+from unittest import TestCase
 from egov.contactdirectory.browser.helper import icon
 
 

--- a/egov/contactdirectory/tests/test_references.py
+++ b/egov/contactdirectory/tests/test_references.py
@@ -1,4 +1,4 @@
-from unittest2 import TestCase
+from unittest import TestCase
 from egov.contactdirectory.testing import EGOV_CONTACTDIRECTORY_INTEGRATION_TESTING
 from plone.app.testing import TEST_USER_ID, TEST_USER_NAME
 from plone.app.testing import login, setRoles

--- a/egov/contactdirectory/tests/test_sync.py
+++ b/egov/contactdirectory/tests/test_sync.py
@@ -7,7 +7,7 @@ from egov.contactdirectory.testing import EGOV_CONTACTDIRECTORY_INTEGRATION_TEST
 from egov.contactdirectory.tests.utils import get_ldif_records
 from ftw.builder import Builder
 from ftw.builder import create
-from unittest2 import TestCase
+from unittest import TestCase
 from zope.interface import implements
 from zope.interface import Interface
 from zope.component import adapts

--- a/setup.py
+++ b/setup.py
@@ -8,8 +8,7 @@ tests_require = ['plone.app.testing',
                  'ftw.builder',
                  'ftw.testbrowser',
                  'ftw.zipexport',
-                 'python-ldap < 3.0.0b1',
-                 'Products.PloneLDAP',
+                 'egov.contactdirectory [ldap]',
                  ]
 
 extras_require = {
@@ -53,7 +52,10 @@ setup(name='egov.contactdirectory',
       tests_require=tests_require,
       extras_require=dict(tests=tests_require,
                           zip_export=['ftw.zipexport'],
-                          ldap=['python-ldap < 3.0.0b1', 'Products.PloneLDAP']),
+                          ldap=['python-ldap < 3.0.0b1',
+                                'Products.PloneLDAP',
+                                'Products.LDAPUserFolder <3a',  # Zope2 compatibility
+                                ]),
 
       entry_points="""
       # -*- Entry points: -*-

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,6 @@ tests_require = ['plone.app.testing',
                  'ftw.builder',
                  'ftw.testbrowser',
                  'ftw.zipexport',
-                 'unittest2',
                  'python-ldap < 3.0.0b1',
                  'Products.PloneLDAP',
                  ]

--- a/test-plone-4.2.x.cfg
+++ b/test-plone-4.2.x.cfg
@@ -1,6 +1,0 @@
-[buildout]
-extends =
-    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.2.x.cfg
-    sources.cfg
-
-package-name = egov.contactdirectory

--- a/test-plone-4.3.x.cfg
+++ b/test-plone-4.3.x.cfg
@@ -4,3 +4,8 @@ extends =
     sources.cfg
 
 package-name = egov.contactdirectory
+
+
+[versions]
+# Apply ftw.contentpage contstraint.
+collective.geo.openlayers = <4.0,>=3.0


### PR DESCRIPTION
- Use unittest instead of unittest2 for testing.
- Drop support for Plone 4.2.
- Add version pinning for collective.geo.openlayers to buildout.
- Pin down Products.LDAPUserFolder to a compatible version.